### PR TITLE
Cleanup command line builder

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-__version__ = "v0.2.10"
+__version__ = "v0.3.0"
 
 DESCRIPTION = (
     "Contains classes and helpers to generate WDL without worrying about the syntax. "

--- a/tests/test_task_generation.py
+++ b/tests/test_task_generation.py
@@ -62,7 +62,7 @@ class TestTaskGeneration(unittest.TestCase):
 
         command = Task.Command("echo")
         command.inputs.append(
-            Task.Command.CommandInput(
+            Task.Command.CommandInput.from_fields(
                 "taskGreeting",
                 optional=False,
                 position=None,
@@ -72,7 +72,7 @@ class TestTaskGeneration(unittest.TestCase):
             )
         )
         command.inputs.append(
-            Task.Command.CommandInput(
+            Task.Command.CommandInput.from_fields(
                 "otherInput",
                 optional=True,
                 position=2,
@@ -83,7 +83,7 @@ class TestTaskGeneration(unittest.TestCase):
         )
         command = Task.Command("echo")
         command.inputs.append(
-            Task.Command.CommandInput(
+            Task.Command.CommandInput.from_fields(
                 "taskGreeting",
                 optional=False,
                 position=None,
@@ -93,7 +93,7 @@ class TestTaskGeneration(unittest.TestCase):
             )
         )
         command.inputs.append(
-            Task.Command.CommandInput(
+            Task.Command.CommandInput.from_fields(
                 "otherInput",
                 optional=True,
                 position=2,
@@ -132,8 +132,8 @@ class TestTaskGeneration(unittest.TestCase):
 class TestCommandGeneration(unittest.TestCase):
     def test_simple_command(self):
         command = Task.Command("egrep")
-        command.inputs.append(Task.Command.CommandInput("pattern"))
-        command.inputs.append(Task.Command.CommandInput("in"))
+        command.inputs.append(Task.Command.CommandInput("~{pattern}"))
+        command.inputs.append(Task.Command.CommandInput("~{in}"))
 
         expected = """\
 egrep \\
@@ -145,7 +145,7 @@ egrep \\
     def test_readme_example(self):
         command = Task.Command("echo")
         command.inputs.append(
-            Task.Command.CommandInput(
+            Task.Command.CommandInput.from_fields(
                 "taskGreeting",
                 optional=False,
                 position=None,
@@ -155,7 +155,7 @@ egrep \\
             )
         )
         command.inputs.append(
-            Task.Command.CommandInput(
+            Task.Command.CommandInput.from_fields(
                 "otherInput",
                 optional=True,
                 position=2,
@@ -172,7 +172,7 @@ echo \\
         self.assertEqual(expected, command.get_string())
 
     def test_commandinput_space(self):
-        t = Task.Command.CommandInput(
+        t = Task.Command.CommandInput.from_fields(
             "taskGreeting",
             optional=False,
             position=None,
@@ -183,7 +183,7 @@ echo \\
         self.assertEqual("-a ~{taskGreeting}", t.get_string())
 
     def test_commandinput_nospace(self):
-        t = Task.Command.CommandInput(
+        t = Task.Command.CommandInput.from_fields(
             "taskGreeting",
             optional=False,
             position=None,
@@ -194,13 +194,13 @@ echo \\
         self.assertEqual("val=~{taskGreeting}", t.get_string())
 
     def test_commandarg_space(self):
-        t = Task.Command.CommandInput(
+        t = Task.Command.CommandInput.from_fields(
             "argVal", position=None, prefix="-p", separate_value_from_prefix=True
         )
         self.assertEqual("-p ~{argVal}", t.get_string())
 
     def test_commandarg_nospace(self):
-        t = Task.Command.CommandArgument(
+        t = Task.Command.CommandArgument.from_fields(
             prefix="arg=",
             value="argVal",
             position=None,

--- a/tests/test_task_generation.py
+++ b/tests/test_task_generation.py
@@ -208,6 +208,28 @@ echo \\
         )
         self.assertEqual("arg=argVal", t.get_string())
 
+    def test_commandarg_flag(self):
+        t = Task.Command.CommandInput.from_fields(
+            name="my_value",
+            true="--arg"
+        )
+        self.assertEqual("~{if (my_value) then \"--arg\" else \"\"}", t.get_string())
+
+    def test_commandarg_flag_false(self):
+        t = Task.Command.CommandInput.from_fields(
+            name="my_value",
+            false="--arg"
+        )
+        self.assertEqual("~{if (my_value) then \"\" else \"--arg\"}", t.get_string())
+
+    def test_commandinp_array_inp(self):
+        t = Task.Command.CommandInput.from_fields(
+            name="my_array",
+            separator=" ",
+            default=[]
+        )
+        self.assertEqual("~{sep(" ", if defined(my_array) then my_array else [])}", t.get_string())
+
 
 class TestWorkflowGeneration(unittest.TestCase):
     def test_hello_workflow(self):


### PR DESCRIPTION
I've never really been happy with the command line builder - this has sort of led me to half-implement building the command line with wdlgen, and half in an external project.

I guess it depends what you want from this project, but I don't believe the core should be taking care of that for you - I believe it should be a more faithful representation of WDL.

For this reason, in v0.3.0 I've removed the option to provide components to the `Task.Command.CommandInput` (which would construct the workflow for you). This behaviour will still exist temporarily in in `Task.Command.CommandInput.from_fields`, but with a number of PRs coming to cleanup these string interpolation options and provide a quoting mechanic, I don't think we need to do this.

